### PR TITLE
(#292) jjv-free loading

### DIFF
--- a/lib/json/permissive-validator.js
+++ b/lib/json/permissive-validator.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2016 aixigo AG
+ * Released under the MIT license.
+ * http://laxarjs.org/license
+ */
+define( [], function() {
+   'use strict';
+
+   function ValidationError() {
+   }
+
+   function expand( schema, value ) {
+      if( !schema.hasOwnProperty( 'type' ) ) {
+         return;
+      }
+
+      if( schema.type === 'array' ) {
+         if( !Array.isArray( value ) ) {
+            throw new ValidationError();
+         }
+         if( schema.hasOwnProperty( 'items' ) ) {
+            expandItems( schema, value );
+         }
+         // :TODO: correctly interpret array-valued items, and additionalItems
+      }
+
+      if( schema.type === 'object' ) {
+         if( typeof value !== 'object' ) {
+            throw new ValidationError();
+         }
+         expandProperties( schema, value );
+         expandPatternProperties( schema, value );
+         expandAdditionalProperties( schema, value );
+      }
+   }
+
+   function expandItems( schema, value ) {
+      var itemsSchema = schema.items;
+      if( typeof( itemsSchema ) === 'object' ) {
+         if( Array.isArray( value ) ) {
+            value.forEach( function( itemValue ) {
+               expand( itemsSchema, itemValue );
+            } );
+         }
+      }
+   }
+
+   function expandProperties( schema, value ) {
+      var properties = schema.properties;
+      if( typeof( properties ) !== 'object' ) { return; }
+      for( var key in properties ) {
+         if( properties.hasOwnProperty( key ) ) {
+            var propertySchema = properties[ key ];
+            descend( propertySchema, value, key );
+         }
+      }
+   }
+
+   function expandPatternProperties( schema, value ) {
+      var patternProperties = schema.patternProperties;
+      if( typeof( patternProperties ) !== 'object' ) { return; }
+      for( var pattern in patternProperties ) {
+         if( patternProperties.hasOwnProperty( pattern ) ) {
+            var propertySchema = patternProperties[ pattern ];
+            var regexp = new RegExp( pattern );
+            for( var key in value ) {
+               if( value.hasOwnProperty( key ) ) {
+                  if( regexp.test( key ) ) {
+                     descend( propertySchema, value, key );
+                  }
+               }
+            }
+         }
+      }
+   }
+
+   function expandAdditionalProperties( schema, value ) {
+      var additionalPropertiesSchema = schema.additionalProperties;
+      if( typeof( additionalPropertiesSchema ) !== 'object' ) { return; }
+      for( var key in value ) {
+         if( value.hasOwnProperty( key ) ) {
+            descend( additionalPropertiesSchema, value, key );
+         }
+      }
+   }
+
+   function descend( innerSchema, value, key ) {
+      if( value.hasOwnProperty( key ) && value[ key ] !== undefined ) {
+         expand( innerSchema, value[ key ] );
+      }
+      else if( innerSchema.default !== undefined ) {
+         value[ key ] = innerSchema.default;
+      }
+   }
+
+   function create( schema, options ) {
+      return {
+         addFormat: function() {},
+         validate: function( jsonValue ) {
+            expand( schema, jsonValue );
+            return { errors: [] };
+         }
+      };
+   }
+
+   return {
+      create: create
+   };
+
+} );

--- a/lib/json/real-validator.js
+++ b/lib/json/real-validator.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2016 aixigo AG
+ * Released under the MIT license.
+ * http://laxarjs.org/license
+ */
+define( [
+   'jjv',
+   'jjve',
+   './schema',
+   '../utilities/object'
+], function( jjv, jjve, schema, objectUtils ) {
+   'use strict';
+
+   var JSON_SCHEMA_V4_URI = 'http://json-schema.org/draft-04/schema#';
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+   function transformResult( result, schema, object, env ) {
+      if( !result ) {
+         return {
+            errors: []
+         };
+      }
+
+      var messageGenerator = jjve( env );
+
+      return {
+         errors: messageGenerator( schema, object, result )
+            .map( function( error ) {
+               return objectUtils.options( {
+                  message: error.message + '. Path: "' + error.path + '".'
+               }, error );
+            } )
+      };
+   }
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+   return {
+
+      /**
+       * Creates and returns a new JSON validator for schema draft version 4. Minimal conversion from v3 to v4
+       * is builtin, but it is strongly advised to create new schemas using the version 4 draft. Version
+       * detection for v4 is realized by checking if the `$schema` property of the root schema equals the
+       * uri `http://json-schema.org/draft-04/schema#`. If the `$schema` property is missing or has a
+       * different value, v3 is assumed.
+       * See https://github.com/json-schema/json-schema/wiki/ChangeLog for differences between v3 and v4.
+       *
+       * @param {Object} jsonSchema
+       *    the JSON schema to use when validating
+       * @param {Object} [options]
+       *    an optional set of options
+       * @param {Boolean} options.prohibitAdditionalProperties
+       *    sets additionalProperties to false if not defined otherwise for the according object schema
+       * @param {Boolean} options.checkRequired
+       *    (jjv option) if `true` it reports missing required properties, otherwise it allows missing
+       *    required properties. Default is `true`
+       * @param {Boolean} options.useDefault
+       *    (jjv option) If true it modifies the validated object to have the default values for missing
+       *    non-required fields. Default is `false`
+       * @param {Boolean} options.useCoerce
+       *    (jjv option) if `true` it enables type coercion where defined. Default is `false`
+       * @param {Boolean} options.removeAdditional
+       *    (jjv option) if `true` it removes all attributes of an object which are not matched by the
+       *    schema's specification. Default is `false`
+       *
+       *
+       * @return {Object}
+       *    a new instance of JsonValidator
+       */
+      create: function( jsonSchema, options ) {
+         var env = jjv();
+         options = objectUtils.options( options, {
+            prohibitAdditionalProperties: false
+         } );
+         env.defaultOptions = objectUtils.options( options, env.defaultOptions );
+
+         if( !( '$schema' in jsonSchema ) || jsonSchema.$schema !== JSON_SCHEMA_V4_URI ) {
+            // While schema draft v4 is directly supported by the underlying validator, we need to transform
+            // older v3 schemas to valid v4 schemas. Furthermore all of our existing schemas are v3 without
+            // version info. Thus, whenever we find a schema without version info or a version info that isn't
+            // v4, we assume a v3 schema and translate it to v4.
+            // Note that only the small subset of v3 features is transformed v4 features that is needed for
+            // legacy schemas.
+            // Using `this` reference for testability / spying
+            jsonSchema = schema.transformV3ToV4( jsonSchema );
+            jsonSchema.$schema = JSON_SCHEMA_V4_URI;
+
+            env.addType( 'any', function( value ) {
+               return true;
+            } );
+         }
+
+         if( options.prohibitAdditionalProperties ) {
+            schema.prohibitAdditionalProperties( jsonSchema );
+         }
+
+         var origValidate = env.validate;
+
+         env.validate = function( object ) {
+            var result = origValidate.call( env, jsonSchema, object );
+            return transformResult( result, jsonSchema, object, env );
+         };
+
+         return env;
+      },
+
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+      JSON_SCHEMA_V4_URI: JSON_SCHEMA_V4_URI
+
+   };
+
+} );

--- a/lib/json/spec/permissive_validator_spec.js
+++ b/lib/json/spec/permissive_validator_spec.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2016 aixigo AG
+ * Released under the MIT license.
+ * http://laxarjs.org/license
+ */
+define( [
+   '../permissive-validator',
+   '../schema',
+   'jjv'
+], function( permissiveValidator, schema, jjv ) {
+   'use strict';
+
+   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+   describe( 'A permissive Validator', function() {
+
+
+      function check( schema, options, testcases ) {
+         var env = jjv();
+         env.addSchema( 'schema', schema );
+         var pv = permissiveValidator.create( schema, options );
+
+         testcases.forEach( function( data ) {
+            var data_valid = JSON.parse( JSON.stringify( data ) );
+            env.validate( 'schema', data_valid );
+            pv.validate( data );
+            expect( data ).toEqual( data_valid );
+         } );
+
+      }
+
+      it( 'instantiates default values', function() {
+         var schema = {
+             '$schema': 'http://json-schema.org/draft-04/schema#',
+             'type': 'object',
+             'required': [
+                 'places'
+             ],
+             'properties': {
+                 'places': {
+                     'type': 'object',
+                     'description': 'The places for this flow.',
+                     'patternProperties': {
+                         '[a-z][a-zA-Z0-9_]*': {
+                             'type': 'object',
+                             'properties': {
+                                 'redirectTo': {
+                                     'type': 'string',
+                                     'description': 'The place to redirect to when hitting this place.'
+                                 },
+                                 'page': {
+                                     'type': 'string',
+                                     'description': 'The page to render for this place.'
+                                 },
+                                 'targets': {
+                                     'type': 'object',
+                                     'patternProperties': {
+                                         '[a-z][a-zA-Z0-9_]*': {
+                                             'type': 'string'
+                                         }
+                                     },
+                                     'description':
+                                        'A map of symbolic targets to places reachable from this place.'
+                                 },
+                                 'entryPoints': {
+                                     'type': 'object',
+                                     'patternProperties': {
+                                         '[a-z][a-zA-Z0-9_]*': {
+                                             'type': 'string'
+                                         }
+                                     },
+                                     'description': 'Entry points defined by this place.'
+                                 },
+                                 'exitPoint': {
+                                     'type': 'string',
+                                     'description': 'The exit point to invoke when reaching this place.'
+                                 }
+                             },
+                             'additionalProperties': false
+                         }
+                     },
+                     'additionalProperties': false
+                 }
+             },
+             'additionalProperties': false
+         };
+
+         var testcases = [
+            {
+                'places': {
+                    'entry': {
+                        'redirectTo': 'investify'
+                    },
+                    'investify/:selectedColumn/:selectedUser/:details': {
+                        'page': 'single_page',
+                        'targets': {}
+                    },
+                    'email-validation/': {
+                        'page': 'email_validation_page',
+                        'targets': {}
+                    },
+                    'change-password/': {
+                        'page': 'change_password_page',
+                        'targets': {}
+                    }
+                }
+            }
+         ];
+
+         check( schema, {}, testcases );
+      } );
+
+   } );
+
+} );

--- a/lib/json/spec/spec_runner.js
+++ b/lib/json/spec/spec_runner.js
@@ -9,7 +9,8 @@
       title: 'JSON lib Specification',
       tests: [
          'schema_spec',
-         'validator_spec'
+         'validator_spec',
+         'permissive_validator_spec'
       ],
       requireConfig: {
          map: {

--- a/lib/json/validator.js
+++ b/lib/json/validator.js
@@ -4,111 +4,28 @@
  * http://laxarjs.org/license
  */
 define( [
-   'jjv',
-   'jjve',
-   './schema',
-   '../utilities/object'
-], function( jjv, jjve, schema, objectUtils ) {
+//>>includeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   './permissive-validator',
+//>>includeEnd("disableJsonValidation");
+//>>excludeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   './real-validator',
+//>>excludeEnd("disableJsonValidation");
+   './schema' // not really needed, only used as a syntactic hack, to make this file parse without preprocessing
+], function(
+//>>includeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   permissiveValidator,
+//>>includeEnd("disableJsonValidation");
+//>>excludeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   realValidator,
+//>>excludeEnd("disableJsonValidation");
+   schema  ) {
    'use strict';
-
-   var JSON_SCHEMA_V4_URI = 'http://json-schema.org/draft-04/schema#';
-
-   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-   function transformResult( result, schema, object, env ) {
-      if( !result ) {
-         return {
-            errors: []
-         };
-      }
-
-      var messageGenerator = jjve( env );
-
-      return {
-         errors: messageGenerator( schema, object, result )
-            .map( function( error ) {
-               return objectUtils.options( {
-                  message: error.message + '. Path: "' + error.path + '".'
-               }, error );
-            } )
-      };
-   }
-
-   ///////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-   return {
-
-      /**
-       * Creates and returns a new JSON validator for schema draft version 4. Minimal conversion from v3 to v4
-       * is builtin, but it is strongly advised to create new schemas using the version 4 draft. Version
-       * detection for v4 is realized by checking if the `$schema` property of the root schema equals the
-       * uri `http://json-schema.org/draft-04/schema#`. If the `$schema` property is missing or has a
-       * different value, v3 is assumed.
-       * See https://github.com/json-schema/json-schema/wiki/ChangeLog for differences between v3 and v4.
-       *
-       * @param {Object} jsonSchema
-       *    the JSON schema to use when validating
-       * @param {Object} [options]
-       *    an optional set of options
-       * @param {Boolean} options.prohibitAdditionalProperties
-       *    sets additionalProperties to false if not defined otherwise for the according object schema
-       * @param {Boolean} options.checkRequired
-       *    (jjv option) if `true` it reports missing required properties, otherwise it allows missing
-       *    required properties. Default is `true`
-       * @param {Boolean} options.useDefault
-       *    (jjv option) If true it modifies the validated object to have the default values for missing
-       *    non-required fields. Default is `false`
-       * @param {Boolean} options.useCoerce
-       *    (jjv option) if `true` it enables type coercion where defined. Default is `false`
-       * @param {Boolean} options.removeAdditional
-       *    (jjv option) if `true` it removes all attributes of an object which are not matched by the
-       *    schema's specification. Default is `false`
-       *
-       *
-       * @return {Object}
-       *    a new instance of JsonValidator
-       */
-      create: function( jsonSchema, options ) {
-         var env = jjv();
-         options = objectUtils.options( options, {
-            prohibitAdditionalProperties: false
-         } );
-         env.defaultOptions = objectUtils.options( options, env.defaultOptions );
-
-         if( !( '$schema' in jsonSchema ) || jsonSchema.$schema !== JSON_SCHEMA_V4_URI ) {
-            // While schema draft v4 is directly supported by the underlying validator, we need to transform
-            // older v3 schemas to valid v4 schemas. Furthermore all of our existing schemas are v3 without
-            // version info. Thus, whenever we find a schema without version info or a version info that isn't
-            // v4, we assume a v3 schema and translate it to v4.
-            // Note that only the small subset of v3 features is transformed v4 features that is needed for
-            // legacy schemas.
-            // Using `this` reference for testability / spying
-            jsonSchema = schema.transformV3ToV4( jsonSchema );
-            jsonSchema.$schema = JSON_SCHEMA_V4_URI;
-
-            env.addType( 'any', function( value ) {
-               return true;
-            } );
-         }
-
-         if( options.prohibitAdditionalProperties ) {
-            schema.prohibitAdditionalProperties( jsonSchema );
-         }
-
-         var origValidate = env.validate;
-
-         env.validate = function( object ) {
-            var result = origValidate.call( env, jsonSchema, object );
-            return transformResult( result, jsonSchema, object, env );
-         };
-
-         return env;
-      },
-
-      ////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-      JSON_SCHEMA_V4_URI: JSON_SCHEMA_V4_URI
-
-   };
-
+   var validator;
+//>>includeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   validator = permissiveValidator;
+//>>includeEnd("disableJsonValidation");
+//>>excludeStart("disableJsonValidation", pragmas.disableJsonValidation);
+   validator = realValidator;
+//>>excludeEnd("disableJsonValidation");
+   return validator;
 } );


### PR DESCRIPTION
Adds a permissive-validator, that only instantiates default values from JSON Schemata into JSON data. The
switch between this permissive JSON validator and the real JSON validator is done by using an optional
requirejs pragma "disableJsonValidation". While this pragma is set to true laxar does not depend on jjv/jjve
anymore.
