### PR TITLE
Fix the path of the whatwg-fetch polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Last Changes
 
+- [#407](https://github.com/LaxarJS/laxar/issues/407): polyfills: converted to ES2015 and fixed fetch-polyfill path
 - [#406](https://github.com/LaxarJS/laxar/issues/406): fixed typo in comments
 - [#396](https://github.com/LaxarJS/laxar/issues/396): adapters: adapter instances no longer need to have a `technology` property
 - [#276](https://github.com/LaxarJS/laxar/issues/276): added and fixed API docs

--- a/polyfills.js
+++ b/polyfills.js
@@ -1,7 +1,7 @@
 /* global require */
 // script-loader works for MSIE (in contrast to the core-js loader)
-require('script!promise-polyfill/promise');
-require('./node_modules/whatwg-fetch/fetch.js');
-require('./lib/polyfills/array_from.js');
-require('./lib/polyfills/array_includes.js');
-require('./lib/polyfills/object_assign.js');
+import 'script!promise-polyfill/promise';
+import 'whatwg-fetch/fetch.js';
+import './lib/polyfills/array_from.js';
+import './lib/polyfills/array_includes.js';
+import './lib/polyfills/object_assign.js';


### PR DESCRIPTION
Shouldn't contain `node_modules`, because some NPM versions move common dependencies up the directory tree. Webpack will resolve it anyway. Also, since the other entry modules are ES2015, this one should be as well. (An earlier ticket ensured that polyfills will be bundled for dist)